### PR TITLE
Fixed: "Undefined index: mem_total_repeats" WP 4.1.1 and Plugin 1.0.7

### DIFF
--- a/mem.php
+++ b/mem.php
@@ -280,7 +280,7 @@ function mem_save_date( $id, $post ) {
 
 		if ($type == 'repeat') {
 			$count_repeats = 1;
-			$total_repeats = $_POST['mem_total_repeats'];
+			$total_repeats = isset($_POST['mem_total_repeats']) ? $_POST['mem_total_repeats'] : 0;
 
 			while ( $count_repeats <= $total_repeats ) {
 


### PR DESCRIPTION
This is a fix for PHP strict causes Undefined index error #10, not sure if you had something more elaborate in mind. 
